### PR TITLE
Onboarding of product-traceability-foss on development environment

### DIFF
--- a/argocd/product-traceability-foss/base-read-only/resources/argo-project.yaml
+++ b/argocd/product-traceability-foss/base-read-only/resources/argo-project.yaml
@@ -25,6 +25,6 @@ spec:
         - p, proj:project-traceability-foss:project-read-only, applications, get, project-traceability-foss/*, allow
         - p, proj:project-traceability-foss:project-read-only, exec, create, project-traceability-foss/*, allow
       groups:
-        - Cofinity-x:Trace-X
-        - Cofinity-x:release-management
-        - Cofinity-x:test-management
+        - Cofinity-X:Trace-X
+        - Cofinity-X:release-management
+        - Cofinity-X:test-management

--- a/argocd/product-traceability-foss/base-read-only/resources/argo-project.yaml
+++ b/argocd/product-traceability-foss/base-read-only/resources/argo-project.yaml
@@ -10,8 +10,6 @@ spec:
   destinations:
     - namespace: product-traceability-foss
       server: https://kubernetes.default.svc
-    - namespace: product-traceability-foss-pen
-      server: https://kubernetes.default.svc
   # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
   namespaceResourceBlacklist:
     - group: ''
@@ -27,6 +25,6 @@ spec:
         - p, proj:project-traceability-foss:project-read-only, applications, get, project-traceability-foss/*, allow
         - p, proj:project-traceability-foss:project-read-only, exec, create, project-traceability-foss/*, allow
       groups:
-        - catenax-ng:product-traceability-foss
-        - catenax-ng:release-management
-        - catenax-ng:test-management
+        - Cofinity-x:Trace-X
+        - Cofinity-x:release-management
+        - Cofinity-x:test-management

--- a/argocd/product-traceability-foss/base-read-only/resources/avp-secret.yaml
+++ b/argocd/product-traceability-foss/base-read-only/resources/avp-secret.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: product-traceability-foss
 type: Opaque
 stringData:
-  VAULT_ADDR: https://vault.demo.catena-x.net/
+  VAULT_ADDR: https://vault.cofinity-x.com/
   AVP_TYPE: vault
   AVP_AUTH_TYPE: approle
   AVP_ROLE_ID: <role_id>

--- a/argocd/product-traceability-foss/read-write/kustomization.yaml
+++ b/argocd/product-traceability-foss/read-write/kustomization.yaml
@@ -4,9 +4,9 @@ kind: Kustomization
 bases:
   - ../base-read-only
 
-resources:
-  - resources/avp-secret.yaml
-  - resources/namespace.yaml
+# resources:
+#   - resources/avp-secret.yaml
+#   - resources/namespace.yaml
 
 patchesStrategicMerge:
   - resources/argo-project.yaml

--- a/argocd/product-traceability-foss/read-write/resources/argo-project.yaml
+++ b/argocd/product-traceability-foss/read-write/resources/argo-project.yaml
@@ -14,11 +14,11 @@ spec:
         - p, proj:project-traceability-foss:team-admin, applications, *, project-traceability-foss/*, allow
         - p, proj:project-traceability-foss:team-admin, exec, create, project-traceability-foss/*, allow
       groups:
-        - Cofinity-x:Trace-x
+        - Cofinity-X:Trace-X
     - name: read-only
       description: Read only access to the project
       policies:
         - p, proj:project-traceability-foss:read-only, applications, get, project-traceability-foss/*, allow
       groups:
-        - Cofinity-x:release-management
-        - Cofinity-x:test-management
+        - Cofinity-X:release-management
+        - Cofinity-X:test-management

--- a/argocd/product-traceability-foss/read-write/resources/argo-project.yaml
+++ b/argocd/product-traceability-foss/read-write/resources/argo-project.yaml
@@ -7,8 +7,6 @@ spec:
   destinations:
     - namespace: product-traceability-foss
       server: https://kubernetes.default.svc
-    - namespace: product-traceability-foss-pen
-      server: https://kubernetes.default.svc
   roles:
     - name: team-admin
       description: All access to applications inside project-traceability-foss.
@@ -16,11 +14,11 @@ spec:
         - p, proj:project-traceability-foss:team-admin, applications, *, project-traceability-foss/*, allow
         - p, proj:project-traceability-foss:team-admin, exec, create, project-traceability-foss/*, allow
       groups:
-        - catenax-ng:product-traceability-foss
+        - Cofinity-x:Trace-x
     - name: read-only
       description: Read only access to the project
       policies:
         - p, proj:project-traceability-foss:read-only, applications, get, project-traceability-foss/*, allow
       groups:
-        - catenax-ng:release-management
-        - catenax-ng:test-management
+        - Cofinity-x:release-management
+        - Cofinity-x:test-management

--- a/cluster/dev/kustomization.yaml
+++ b/cluster/dev/kustomization.yaml
@@ -25,7 +25,7 @@ resources:
 # - ../../argocd/product-r-strategy-assistant/read-write
 - ../../argocd/product-semantics/read-write
 # - ../../argocd/product-test-data-generator/read-write
-# - ../../argocd/product-traceability-foss/read-write
+- ../../argocd/product-traceability-foss/read-write
 # - ../../argocd/product-traceability-irs/read-write
 - ../../argocd/product-value-added-service/read-write
 - ../../argocd/product-registry-twin-check/read-write

--- a/vault/terraform.tfvars
+++ b/vault/terraform.tfvars
@@ -171,15 +171,16 @@ product_teams = {
   #   github_team : "product-test-data-generator"
   #   avp_secret_name : "test-data-generator"
   # },
-  # "traceability-foss" : {
-  #   name : "traceability-foss",
-  #   secret_engine_name : "traceability-foss"
-  #   ui_policy_name : "traceability-foss-rw"
-  #   approle_name : "traceability-foss" # traceability-foss-backend also exists
-  #   approle_policy_name : "traceability-foss-ro"
-  #   github_team : "product-traceability-foss"
-  #   avp_secret_name : "traceability-foss" # product-traceability-foss also exists
-  # },
+  "traceability-foss" : {
+    name : "traceability-foss",
+    secret_engine_name : "traceability-foss"
+    ui_policy_name : "traceability-foss-rw"
+    approle_name : "traceability-foss" # traceability-foss-backend also exists
+    approle_policy_name : "traceability-foss-ro"
+    github_team : "Trace-X"
+    github_team_slug : "trace-x"
+    avp_secret_name : "traceability-foss" # product-traceability-foss also exists
+  },
   # "behaviour-twin-pilot" : {
   #   name : "behaviour-twin-pilot"
   #   secret_engine_name : "behaviour-twin-pilot"


### PR DESCRIPTION
This PR describes the changes to onboard the product-traceability-foss in the development environment

Changes Introduced:

- Uncommented `argocd` resource `product-traceability-foss` in `cluster/dev/kustomization.yaml`
- Uncommented `product_teams.traceability-foss` and added `github_team, github_team_slug` attribute in  `product_teams.traceability-foss`  in `vault/terraform.tfvars`
- Changed name from `catena-x` to `Cofinity-X` in `groups` property in `argocd/product-traceability-foss/base-read-only/resources/argo-project.yaml`
- Changed `VAULT_ADDR` property value in `argocd/product-traceability-foss/base-read-only/resources/avp-secret.yaml`
- Changed name from `catena-x` to `Cofinity-X` in `groups` property in `argocd/product-traceability-foss/read-write/resources/argo-project.yaml`
- Commented `resources` property in `argocd/product-traceability-foss/read-write/kustomization.yaml`


Signed-off-by: @ChauhanKrunal (chauhan.krunal.r@gmail.com)